### PR TITLE
Add the 'verbose' option

### DIFF
--- a/luastyle/__main__.py
+++ b/luastyle/__main__.py
@@ -44,6 +44,11 @@ def main():
                          dest='debug',
                          help='enable debugging messages',
                          default=False)
+    cli_group.add_option('-v', '--verbose',
+                         action='store_true',
+                         dest='verbose',
+                         help='enable statistic messages',
+                         default=False)
     cli_group.add_option('-j', '--jobs',
                          metavar='N', type="int",
                          dest='jobs',
@@ -213,7 +218,7 @@ def main():
     else:
         indent_options = IndentOptions()
         indent_options.indent_size = options.indent_size
-        indent_options.indent_char = ord(options.indent_char)
+        indent_options.indent_char = options.indent_char
         indent_options.indent_with_tabs = options.indent_with_tabs
         indent_options.initial_indent_level = options.initial_indent_level
 
@@ -252,7 +257,8 @@ def main():
     FilesProcessor(options.replace,
                    options.jobs,
                    options.check_bytecode,
-                   indent_options).run(filenames)
+                   indent_options,
+                   options.verbose).run(filenames)
 
 
 if __name__ == '__main__':

--- a/luastyle/core.py
+++ b/luastyle/core.py
@@ -28,11 +28,12 @@ class Configuration:
 
 
 class FilesProcessor:
-    def __init__(self, rewrite, jobs, check_bytecode, indent_options):
+    def __init__(self, rewrite, jobs, check_bytecode, indent_options, verbose):
         self._rewrite = rewrite
         self._jobs = jobs
         self._check_bytecode = check_bytecode
         self._indent_options = indent_options
+        self.verbose = verbose
 
     def _process_one(self, filepath):
         """Process one file.
@@ -60,10 +61,12 @@ class FilesProcessor:
         return bytecode_equal, len(rule_output.split('\n'))
 
     def run(self, files):
-        print(str(len(files)) + ' file(s) to process')
+        if self.verbose:
+            print(str(len(files)) + ' file(s) to process')
 
         processed = 0
-        print('[' + str(processed) + '/' + str(len(files)) + '] file(s) processed')
+        if self.verbose:
+            print('[' + str(processed) + '/' + str(len(files)) + '] file(s) processed')
 
         # some stats
         start = time.time()
@@ -84,11 +87,13 @@ class FilesProcessor:
                     print('%r generated an exception: %s' % (file, exc))
                 else:
                     processed += 1
-                    print('[' + str(processed) + '/' + str(len(files)) + '] file(s) processed, last is ' + file)
+                    if self.verbose:
+                        print('[' + str(processed) + '/' + str(len(files)) + '] file(s) processed, last is ' + file)
                     sys.stdout.flush()
 
         end = time.time()
-        print(str(total_lines) + ' source lines processed in ' + str(round(end - start, 2)) + ' s')
+        if self.verbose:
+            print(str(total_lines) + ' source lines processed in ' + str(round(end - start, 2)) + ' s')
 
 
 def check_lua_bytecode(raw, formatted):


### PR DESCRIPTION
Hi!

I tried to plug your formatter into Chiel92/vim-autoformat plugin and faced  with a problem of excess messages - after formatting the file was appended with info about processed files and so on.

So I decided to add option 'verbose' to the luastyle. By default its value is False, therefore there is no excess output now.

Please consider ability to include this small but useful option to your code.